### PR TITLE
Use directConnect along with Jasmine 2

### DIFF
--- a/e2e-tests/protractor.conf.js
+++ b/e2e-tests/protractor.conf.js
@@ -1,4 +1,6 @@
 exports.config = {
+  directConnect: true,
+  
   allScriptsTimeout: 11000,
 
   specs: [
@@ -11,9 +13,10 @@ exports.config = {
 
   baseUrl: 'http://localhost:8000/app/',
 
-  framework: 'jasmine',
+  framework: 'jasmine2',
 
   jasmineNodeOpts: {
+    showColors: true,
     defaultTimeoutInterval: 30000
   }
 };


### PR DESCRIPTION
Updated protractor conf to use Jasmine 2 and ChromeDriver's directConnect feature to bypass Selenium Server connect directly to the browser. This change does not break the tests (except for async ones but it's rare to use async stuff in protractor tests: https://angular.github.io/protractor/#/jasmine-upgrade#asynchronous-specs)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material-start/35)
<!-- Reviewable:end -->
