### PR TITLE
Removes unneeded ./node_modules/.bin prefix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "scripts": {
     "postinstall": "bower update",
     "prestart": "npm update",
-    "test": "./node_modules/.bin/protractor ./e2e/protractor.conf.js"
+    "test": "protractor ./e2e/protractor.conf.js"
   }
 }


### PR DESCRIPTION
`./node_modules/.bin/` is automatically added to the path when using `npm run`.