### PR TITLE
added jasmine-core to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "angular-mocks": "^1.4.9",
+    "jasmine-core": "^2.4.1",
     "karma": "^0.13.19",
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
added **jasmine-core** to *devDependencies*

While trying to understand unit tests I stumbled across the little bug, that the jasmine-core is not a devDependency. The tests with karma and jasmine wont be able to run, unless you have the jasmine-core already installed globally.