### PR TITLE
Converting 'git+ssh' dependency to 'npm' dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "angular-animate": "^1.5.5",
     "angular-aria": "^1.5.5",
     "angular-messages": "^1.5.5",
-    "angular-material": "git+ssh://git@github.com/angular/bower-material.git#master"
+    "angular-material": "^1.1.0"
   },
   "scripts": {
     "postinstall": "bower update",


### PR DESCRIPTION
It fixed 'npm install' error on my machine.

![25-8-2016 8-01-56 am](https://cloud.githubusercontent.com/assets/6315466/17953056/40363e7c-6a9a-11e6-8f48-7e5395f23ee2.png)
