### PR TITLE
Remove a trailing comma causing an invalid package.json file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "http-server": "^0.6.1",
     "bower": "^1.3.1",
-    "shelljs": "^0.2.6",
+    "shelljs": "^0.2.6"
   },
   "scripts": {
     "postinstall": "bower update",


### PR DESCRIPTION
It fixed 'npm install' error on my machine.

![image](https://cloud.githubusercontent.com/assets/6315466/18070279/f9ee92ee-6e76-11e6-8f72-955a44591736.png)
