### PR TITLE
chore(): use local node modules for jspm

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,10 @@ installed.
 Clone this repository and execute the following commands in a terminal:
 
 * `git checkout master`
-* `npm install jspm live-server -g`
-* `jspm update`
-* `live-server --open=app`
+* `npm install`
+* `npm run serve`
 
-> **Note:** You should use a web-server (like live-server above) to view your app in the browser. Open
-  the dev console to see any warnings and browse the elements.
+> **Note:** Open the dev console to see any warnings and browse the elements.
 
 ###### Layout
 

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     }
   },
   "devDependencies": {
+    "jspm": "^0.16.46",
     "live-server": "^0.9.2"
   },
   "scripts": {
-    "postinstall": "jspm install"
+    "postinstall": "jspm install",
+    "serve": "live-server ./app"
   }
 }


### PR DESCRIPTION
* Rather than forcing the user to install a JSPM binary with NPMg lobally, we should add JSPM as a dev-dependency. This ensures that each user has the *same* environment and same conditions.

* Notice that JSPM will automatically install the packages when running `npm install`, because it's listed in the `postinstall` script.

cc. @ThomasBurleson